### PR TITLE
Viking.ByteStream IO functions

### DIFF
--- a/src/Viking/ByteStream.hs
+++ b/src/Viking/ByteStream.hs
@@ -1,6 +1,118 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 module Viking.ByteStream (
     module Data.ByteString.Streaming
+
+  , embed
+
+  , hoistEither
+  , runEitherT
+  , injectEitherT
+
+  , defaultChunkSize
+
+  , readFile
+  , readFileN
+  , writeFile
+
+  , hGetContents
+  , hGetContentsN
+  , hPut
   ) where
 
-import           Data.ByteString.Streaming hiding (ByteString)
+import           Control.Monad.Catch (MonadCatch, try, bracket)
+import           Control.Monad.IO.Class (MonadIO)
+import           Control.Monad.Morph (hoist)
+import           Control.Monad.Trans.Class (lift)
+import           Control.Monad.Trans.Control (MonadBaseControl, liftBaseOp)
+import           Control.Monad.Trans.Resource (MonadResource)
+
+import qualified Data.ByteString.Streaming as Streaming
+import           Data.ByteString.Streaming hiding (ByteString, readFile, writeFile, hGetContents, hGetContentsN, hPut)
+import qualified Data.ByteString.Streaming.Internal as Streaming
+
+import           P
+
+import           System.IO (IO, FilePath, Handle, IOMode(..))
+import qualified System.IO as IO
+import           System.IO.Error (IOError)
+
+import           Viking (ByteStream)
+
+import           X.Control.Monad.Trans.Either (EitherT, pattern EitherT)
+import qualified X.Control.Monad.Trans.Either as EitherT
+
+
+embed :: Monad n => (forall a. m a -> ByteStream n a) -> ByteStream m b -> ByteStream n b
+embed phi =
+  let
+    loop = \case
+      Streaming.Empty r ->
+        Streaming.Empty r
+      Streaming.Chunk bs rest ->
+        Streaming.Chunk bs (loop rest)
+      Streaming.Go m ->
+        loop =<< phi m
+  in
+    loop
+{-# INLINABLE embed #-}
+
+hoistEither :: Monad m => ByteStream m (Either x r) -> ByteStream (EitherT x m) r
+hoistEither =
+  bind (lift . EitherT.hoistEither) . hoist lift
+{-# INLINABLE hoistEither #-}
+
+runEitherT :: Monad m => ByteStream (EitherT x m) r -> ByteStream m (Either x r)
+runEitherT =
+  EitherT.runEitherT . distribute
+{-# INLINABLE runEitherT #-}
+
+injectEitherT :: Monad m => EitherT x (ByteStream m) r -> ByteStream (EitherT x m) r
+injectEitherT =
+  hoistEither . EitherT.runEitherT
+{-# INLINABLE injectEitherT #-}
+
+defaultChunkSize :: Int
+defaultChunkSize =
+  1024 * 1024
+{-# INLINABLE defaultChunkSize #-}
+
+readFileN :: (MonadResource m, MonadCatch m) => Int -> FilePath -> ByteStream (EitherT IOError m) ()
+readFileN chunkSize path =
+  embed (lift . EitherT . try) .
+    Streaming.bracketByteString (IO.openBinaryFile path ReadMode) IO.hClose $
+      Streaming.hGetContentsN chunkSize
+{-# INLINABLE readFileN #-}
+
+readFile :: (MonadResource m, MonadCatch m) => FilePath -> ByteStream (EitherT IOError m) ()
+readFile =
+  readFileN defaultChunkSize
+{-# INLINABLE readFile #-}
+
+writeFile :: (MonadBaseControl IO m, MonadIO m, MonadCatch m) => FilePath -> ByteStream m r -> EitherT IOError m r
+writeFile path bss =
+  EitherT . try $
+    liftBaseOp
+      (bracket (IO.openBinaryFile path WriteMode) (IO.hClose))
+      (\h -> Streaming.hPut h bss)
+{-# INLINABLE writeFile #-}
+
+hGetContentsN :: (MonadIO m, MonadCatch m) => Int -> Handle -> ByteStream (EitherT IOError m) ()
+hGetContentsN chunkSize handle =
+  embed (lift . EitherT . try) $
+    Streaming.hGetContentsN chunkSize handle
+{-# INLINABLE hGetContentsN #-}
+
+hGetContents :: (MonadIO m, MonadCatch m) => Handle -> ByteStream (EitherT IOError m) ()
+hGetContents =
+  hGetContentsN defaultChunkSize
+{-# INLINABLE hGetContents #-}
+
+hPut :: (MonadIO m, MonadCatch m) => Handle -> ByteStream m r -> EitherT IOError m r
+hPut handle bss =
+  EitherT . try $
+    Streaming.hPut handle bss
+{-# INLINABLE hPut #-}

--- a/test/Test/Viking/ByteStream.hs
+++ b/test/Test/Viking/ByteStream.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Viking.ByteStream where
+
+import           Control.Monad.Catch (throwM)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Resource (runResourceT)
+
+import           Hedgehog
+
+import           P
+
+import           System.FilePath ((</>))
+import           System.IO (IO, hClose)
+import           System.IO.Error (IOError, userError)
+import qualified System.IO.Temp as Temp
+
+import qualified Viking.ByteStream as ByteStream
+
+import           X.Control.Monad.Trans.Either (runEitherT)
+
+
+prop_get_contents_exception :: Property
+prop_get_contents_exception =
+  withTests 1 . property . test . runResourceT $ do
+    (_, _, h) <- Temp.openBinaryTempFile Nothing "viking-"
+    liftIO $ hClose h
+
+    x <- runEitherT . ByteStream.effects $ ByteStream.hGetContents h
+    annotateShow x
+
+    assert $
+      isLeft x
+
+prop_read_file_exception :: Property
+prop_read_file_exception =
+  withTests 1 . property . test . runResourceT $ do
+    (_, dir) <- Temp.createTempDirectory Nothing "viking-"
+
+    x <- runEitherT . ByteStream.effects $ ByteStream.readFile (dir </> "foo")
+    annotateShow x
+
+    assert $
+      isLeft x
+
+prop_write_file_exception :: Property
+prop_write_file_exception =
+  withTests 1 . property . test . runResourceT $ do
+    (_, dir) <- Temp.createTempDirectory Nothing "viking-"
+
+    let
+     err =
+       userError "prop_write_file_exception"
+
+    x :: Either IOError () <-
+      runEitherT $ ByteStream.writeFile (dir </> "foo") (throwM err)
+
+    x === Left err
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,5 +1,12 @@
 import           Disorder.Core.Main
 
+import qualified Test.Viking.ByteStream
+import qualified Test.Viking.Char8Stream
+
+
 main :: IO ()
 main =
-  disorderMain []
+  disorderMain [
+      Test.Viking.ByteStream.tests
+    , Test.Viking.Char8Stream.tests
+    ]

--- a/viking.cabal
+++ b/viking.cabal
@@ -16,6 +16,10 @@ library
                      , ambiata-p
                      , ambiata-x-eithert
                      , bytestring                      == 0.10.*
+                     , exceptions                      >= 0.6        && < 0.9
+                     , mmorph                          == 1.0.*
+                     , monad-control                   == 1.0.*
+                     , resourcet                       == 1.1.*
                      , streaming                       == 0.1.*
                      , streaming-bytestring            == 0.1.*
                      , transformers                    >= 0.4        && < 0.6
@@ -48,4 +52,11 @@ test-suite test
                      , ambiata-disorder-corpus
                      , ambiata-p
                      , ambiata-viking
+                     , ambiata-x-eithert
+                     , bytestring                      == 0.10.*
+                     , exceptions                      >= 0.6        && < 0.9
+                     , filepath                        >= 1.3        && < 1.5
                      , hedgehog                        == 0.5.*
+                     , resourcet                       == 1.1.*
+                     , temporary-resourcet             == 0.1.*
+                     , transformers                    >= 0.4        && < 0.6


### PR DESCRIPTION
On top of #6.

These are wrappers for some of the IO functions in `streaming-bytestring` which prevent them from throwing exceptions.

The tests check that if an exception is thrown during the operation, it is indeed reported as a `Left`.

! @tranma @erikd-ambiata @tmcgilchrist 
/jury approved @tmcgilchrist @nhibberd @tranma