### PR TITLE
Relax version constraints

### DIFF
--- a/ambiata-viking.cabal
+++ b/ambiata-viking.cabal
@@ -1,5 +1,5 @@
 name:                  ambiata-viking
-version:               0.0.1
+version:               0.0.1.1
 license:               BSD3
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
@@ -18,12 +18,12 @@ library
                      , binary                          >= 0.7        && < 0.9
                      , bytestring                      == 0.10.*
                      , exceptions                      >= 0.6        && < 0.9
-                     , lifted-async                    == 0.9.*
-                     , mmorph                          == 1.0.*
+                     , lifted-async                    >= 0.9        && < 0.11
+                     , mmorph                          >= 1.0        && < 1.2
                      , monad-control                   == 1.0.*
                      , resourcet                       == 1.1.*
-                     , streaming                       == 0.1.*
-                     , streaming-bytestring            == 0.1.*
+                     , streaming
+                     , streaming-bytestring            >= 0.1        && < 0.2
                      , text                            >= 1.0        && < 1.3
                      , transformers                    >= 0.4        && < 0.6
 
@@ -59,11 +59,11 @@ test-suite test
                      , ambiata-p
                      , ambiata-viking
                      , ambiata-x-eithert
-                     , binary                          >= 0.7        && < 0.9
-                     , bytestring                      == 0.10.*
-                     , exceptions                      >= 0.6        && < 0.9
+                     , binary
+                     , bytestring
+                     , exceptions
                      , filepath                        >= 1.3        && < 1.5
                      , hedgehog                        == 0.5.*
-                     , resourcet                       == 1.1.*
+                     , resourcet
                      , temporary-resourcet             == 0.1.*
-                     , transformers                    >= 0.4        && < 0.6
+                     , transformers


### PR DESCRIPTION
Relax version restrictions a bit to allow newer ghc builds 
(and use of base package versions from ghc 8.0 instead of older ones)
mainly just a copy of Huw's fork's cabal files